### PR TITLE
improvement: use additional nodes instead of styling children directly

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flexbox-primitives",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Flexbox primitives for React Native",
   "main": "src/index.tsx",
   "repository": "https://github.com/emeraldsanto/flexbox-primitives",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -48,12 +48,18 @@ export function Flex({
     >
       {flexGap == null ? (
         children
-      ) : Children.map(children, (child, index) => (
+      ) : Children.toArray(children).map((child, index, array) => (
         <>
           {child}
 
-          {index !== Children.count(children) - 1 && (
-            <View accessibilityElementsHidden accessibilityLiveRegion='none' accessible={false} importantForAccessibility='no' style={{ [sizeProperty]: flexGap }} />
+          {index !== array.length - 1 && (
+            <View
+              accessibilityElementsHidden
+              accessibilityLiveRegion='none'
+              accessible={false}
+              importantForAccessibility='no'
+              style={{ [sizeProperty]: flexGap }}
+            />
           )}
         </>
       ))}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,7 +1,8 @@
+import { Children } from 'react';
 import type { ViewProps, ViewStyle } from 'react-native';
 import { View } from 'react-native';
 
-export type FlexProps = ViewProps &
+export interface FlexProps extends ViewProps,
   Pick<
     ViewStyle,
     | 'alignItems'
@@ -12,12 +13,16 @@ export type FlexProps = ViewProps &
     | 'flexShrink'
     | 'flexWrap'
     | 'justifyContent'
-  >;
+  > {
+  flexGap?: number
+}
 
 export function Flex({
+  children,
   flex,
   flexBasis,
   flexDirection,
+  flexGap,
   flexGrow,
   flexShrink,
   flexWrap,
@@ -38,7 +43,15 @@ export function Flex({
         },
         style,
       ]}
-    />
+    >
+      {flexGap == null ? (
+        children
+      ) : Children.map(children, (child, index) => (
+        <View style={{ marginBottom: index === Children.count(children) - 1 ? 0 : flexGap }}>
+          {child}
+        </View>
+      ))}
+    </View>
   );
 }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -29,7 +29,7 @@ export function Flex({
   style,
   ...rest
 }: FlexProps) {
-  const marginProperty = flexDirection === 'row' ? 'marginEnd' : 'marginTop' as const;
+  const sizeProperty = flexDirection === 'row' ? 'width' : 'height' as const;
 
   return (
     <View
@@ -49,18 +49,22 @@ export function Flex({
       {flexGap == null ? (
         children
       ) : Children.map(children, (child, index) => (
-        <View style={{ [marginProperty]: index === Children.count(children) - 1 ? 0 : flexGap }}>
+        <>
           {child}
-        </View>
+
+          {index !== Children.count(children) - 1 && (
+            <View accessibilityElementsHidden accessibilityLiveRegion='none' accessible={false} importantForAccessibility='no' style={{ [sizeProperty]: flexGap }} />
+          )}
+        </>
       ))}
     </View>
   );
 }
 
-export function Row(props: Omit<FlexProps, 'flexDirection'>) {
-  return <Flex {...props} flexDirection="row" />;
+export function Column(props: Omit<FlexProps, 'flexDirection'>) {
+  return <Flex {...props} flexDirection='column' />;
 }
 
-export function Column(props: Omit<FlexProps, 'flexDirection'>) {
-  return <Flex {...props} flexDirection="column" />;
+export function Row(props: Omit<FlexProps, 'flexDirection'>) {
+  return <Flex {...props} flexDirection='row' />;
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -29,6 +29,8 @@ export function Flex({
   style,
   ...rest
 }: FlexProps) {
+  const marginProperty = flexDirection === 'row' ? 'marginEnd' : 'marginTop' as const;
+
   return (
     <View
       {...rest}
@@ -47,7 +49,7 @@ export function Flex({
       {flexGap == null ? (
         children
       ) : Children.map(children, (child, index) => (
-        <View style={{ marginBottom: index === Children.count(children) - 1 ? 0 : flexGap }}>
+        <View style={{ [marginProperty]: index === Children.count(children) - 1 ? 0 : flexGap }}>
           {child}
         </View>
       ))}


### PR DESCRIPTION
### Summary

This PR moves away from applying margin to the children directly via a parent element in favour of adding additional spacing-only nodes between children. This should prevent styling issues from occurring due to the parent element not honouring the child's flex properties.